### PR TITLE
fix: lib 包源码依赖 element-ui 的问题

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -31,7 +31,7 @@
         ["module-resolver", {
           "root": ["element-ui"],
           "alias": {
-            "element-ui/src": "element-ui/lib"
+            "element-ui/src": "@femessage/element-ui/lib"
           }
         }]
       ]

--- a/build/config.js
+++ b/build/config.js
@@ -7,23 +7,24 @@ var utilsList = fs.readdirSync(path.resolve(__dirname, '../src/utils'));
 var mixinsList = fs.readdirSync(path.resolve(__dirname, '../src/mixins'));
 var transitionList = fs.readdirSync(path.resolve(__dirname, '../src/transitions'));
 var externals = {};
+var packageName = require('../package.json').name;
 
 Object.keys(Components).forEach(function(key) {
-  externals[`element-ui/packages/${key}`] = `element-ui/lib/${key}`;
+  externals[`element-ui/packages/${key}`] = `${packageName}/lib/${key}`;
 });
 
-externals['element-ui/src/locale'] = 'element-ui/lib/locale';
+externals['element-ui/src/locale'] = `${packageName}/lib/locale`;
 utilsList.forEach(function(file) {
   file = path.basename(file, '.js');
-  externals[`element-ui/src/utils/${file}`] = `element-ui/lib/utils/${file}`;
+  externals[`element-ui/src/utils/${file}`] = `${packageName}/lib/utils/${file}`;
 });
 mixinsList.forEach(function(file) {
   file = path.basename(file, '.js');
-  externals[`element-ui/src/mixins/${file}`] = `element-ui/lib/mixins/${file}`;
+  externals[`element-ui/src/mixins/${file}`] = `${packageName}/lib/mixins/${file}`;
 });
 transitionList.forEach(function(file) {
   file = path.basename(file, '.js');
-  externals[`element-ui/src/transitions/${file}`] = `element-ui/lib/transitions/${file}`;
+  externals[`element-ui/src/transitions/${file}`] = `${packageName}/lib/transitions/${file}`;
 });
 
 externals = [Object.assign({


### PR DESCRIPTION
- webpack config externals 处理 component 中与 element-ui 相关的引用路径
- babelrc module-resolver 处理 element-ui/src 中复用 js 相关的引用路径

## Test
npm 私服 + @femessage/create-nuxt-app 初始化项目
![image](https://user-images.githubusercontent.com/27187946/68730571-03b63800-0608-11ea-8c2f-bd33b6540da7.png)

## 遗留问题
@femessage/el-form-renderer 中的 element-ui 依赖需要处理 
