### PR TITLE
ci: 正确的在文档中显示版本号

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ git:
   depth: 3
 install:
   - yarn --frozen-lockfile
-  # deploy 和 dist 之前必须生成一些必要文件
-  - yarn build:file
   - yarn lint --fix
   - yarn test
 script:
   - yarn stdver
+  # deploy 和 dist 之前必须生成一些必要文件
+  - yarn build:file
   - yarn deploy:build
   - yarn dist
 cache: yarn


### PR DESCRIPTION
## CI
![image](https://user-images.githubusercontent.com/27187946/69525540-46cac080-0fa3-11ea-9aa6-76f263d1f534.png)

现在的版本号应该是 2.12.2 才对

排查发现，需要更新了 package version 后再生成对应的基础文件，才能正确的显示仓库版本号