### PR TITLE
fix: 修复 cascader 的删除问题

### DIFF
--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -44,14 +44,14 @@
 
     <div v-if="multiple" class="el-cascader__tags">
       <el-tag
-        v-for="(tag, index) in presentTags"
+        v-for="(tag) in presentTags"
         :key="tag.key"
         type="info"
         :size="tagSize"
         :hit="tag.hitState"
         :closable="tag.closable"
         disable-transitions
-        @close="deleteTag(index)">
+        @close="deleteTag(tag)">
         <span>{{ tag.text }}</span>
       </el-tag>
       <input
@@ -123,7 +123,7 @@ import ElScrollbar from 'element-ui/packages/scrollbar';
 import ElCascaderPanel from 'element-ui/packages/cascader-panel';
 import AriaUtils from 'element-ui/src/utils/aria-utils';
 import { t } from 'element-ui/src/locale';
-import { isEqual, isEmpty, kebabCase } from 'element-ui/src/utils/util';
+import { isEqual, isEmpty, kebabCase, valueEquals } from 'element-ui/src/utils/util';
 import { isUndefined, isFunction } from 'element-ui/src/utils/types';
 import { isDef } from 'element-ui/src/utils/shared';
 import { addResizeListener, removeResizeListener } from 'element-ui/src/utils/resize-event';
@@ -588,7 +588,7 @@ export default {
 
       if (this.pressDeleteCount) {
         if (lastTag.hitState) {
-          this.deleteTag(lastIndex);
+          this.deleteTag(lastTag);
         } else {
           lastTag.hitState = true;
         }
@@ -607,9 +607,11 @@ export default {
         this.toggleDropDownVisible(false);
       }
     },
-    deleteTag(index) {
+    deleteTag(tag) {
       const { checkedValue } = this;
+      const index = checkedValue.findIndex(v => valueEquals(v, tag.node.path));
       const val = checkedValue[index];
+      // 不能用 splice，因为 checkedValue 的监听器会再判断一次引用是否相同
       this.checkedValue = checkedValue.filter((n, i) => i !== index);
       this.$emit('remove-tag', val);
     },
@@ -647,4 +649,3 @@ export default {
   }
 };
 </script>
-

--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -608,8 +608,8 @@ export default {
       }
     },
     deleteTag(tag) {
-      const { checkedValue } = this;
-      const index = checkedValue.findIndex(v => valueEquals(v, tag.node.path));
+      const { checkedValue, props: { emitPath = true }} = this;
+      const index = checkedValue.findIndex(v => valueEquals(v, tag.node[emitPath ? 'path' : 'value']));
       const val = checkedValue[index];
       // 不能用 splice，因为 checkedValue 的监听器会再判断一次引用是否相同
       this.checkedValue = checkedValue.filter((n, i) => i !== index);


### PR DESCRIPTION
## Why
当 value 的顺序与 options 中 value 的顺序不一致时，会出现删错 tag 的问题

## How
删除 tag 时去匹配 node.path 或 node.value （根据 emitPath 判断） 而不是依赖 index

## Test
线下已实际演示过
![image](https://user-images.githubusercontent.com/19591950/71802170-f8c3d500-3097-11ea-9e58-6a163b901c4c.png)
