### PR TITLE
feat(edit-table): formatter 支持返回 `jsx` 和 自定义组件

### DIFF
--- a/examples/docs/zh-CN/edit-table.md
+++ b/examples/docs/zh-CN/edit-table.md
@@ -492,7 +492,7 @@ export default {
           el: {placeholder: '选择性别'},
           default: 'man',
           options: [{label: '男', value: 'man'}, {label: '女', value: 'woman'}],
-          formatter: row => <span style="color: #2a7">{row.sex}</span>
+          formatter: (row, cellValue) => <span style="color: #2a7">{cellValue}</span>
         },
         {
           id: 'readonly',

--- a/examples/docs/zh-CN/edit-table.md
+++ b/examples/docs/zh-CN/edit-table.md
@@ -452,7 +452,7 @@ export default {
 
 ### 使用formatter函数
 
-当edit-table使用了 `readonly` 状态时，可在字段属性自定义 `column.formatter`。该函数接收 `row`, `index` 和 `cellValue` 参数，可返回 JSX(需要项目配置支持), 自定义组件和字符串。不定义则默认返回原数据对应的字段。
+当edit-table使用了 `readonly` 状态时，可在字段属性自定义 `column.formatter`。该函数接收 `row`, `cellValue` 和 `index` 参数，可返回 JSX(需要项目配置支持), 自定义组件和字符串。不定义则默认返回原数据对应的字段。
 
 :::demo
 
@@ -498,7 +498,7 @@ export default {
           id: 'readonly',
           label: '组成句子',
           type: 'input',
-          formatter(row, column) {
+          formatter(row) {
             return row.name?`${row.name} is a ${row.sex}, ${{man: 'his', woman: 'her'}[row.sex] || 'his'} phone number is ${row.phone}`:'Please Input Name'
           }
         }

--- a/examples/docs/zh-CN/edit-table.md
+++ b/examples/docs/zh-CN/edit-table.md
@@ -452,7 +452,7 @@ export default {
 
 ### 使用formatter函数
 
-当edit-table使用了readonly状态时，可在字段属性自定义column.formatter。该函数接收row和index参数，需要返回字符串，暂不支持jsx。不定义则默认返回原数据对应的字段。
+当edit-table使用了 `readonly` 状态时，可在字段属性自定义 `column.formatter`。该函数接收 `row`, `index` 和 `cellValue` 参数，可返回 JSX(需要项目配置支持), 自定义组件和字符串。不定义则默认返回原数据对应的字段。
 
 :::demo
 
@@ -485,7 +485,15 @@ export default {
             }
           ],
         },
-        {id: 'sex' , label: '性别', type: 'select', el: {placeholder: '选择性别'}, default: 'man', options: [{label: '男', value: 'man'}, {label: '女', value: 'woman'}]},
+        {
+          id: 'sex',
+          label: '性别',
+          type: 'select',
+          el: {placeholder: '选择性别'},
+          default: 'man',
+          options: [{label: '男', value: 'man'}, {label: '女', value: 'woman'}],
+          formatter: row => <span style="color: #2a7">{row.sex}</span>
+        },
         {
           id: 'readonly',
           label: '组成句子',

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "markdown-it-container": "^2.0.0",
     "mini-css-extract-plugin": "^0.4.1",
     "mocha": "^6.0.2",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.13.1",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "postcss": "^7.0.14",
     "progress-bar-webpack-plugin": "^1.11.0",

--- a/packages/edit-table/src/form-input.vue
+++ b/packages/edit-table/src/form-input.vue
@@ -65,20 +65,21 @@ export default {
   },
   computed: {
     readonlyComponent() {
-      let Content = this.data[this.column.id];
+      let cellValue = this.data[this.column.id];
+
       let Component = {
-        render: h => h('p', null, Content)
+        render: h => h('p', null, cellValue)
       };
 
       if (isFunction(this.column.formatter)) {
-        const formatted = this.column.formatter(this.data, this.index, Content);
+        const formatted = this.column.formatter(this.data, cellValue, this.index);
 
         if (isVNode(formatted)) {
           Component = { render: h => formatted };
         } else if (isObject(formatted)) {
           Component = formatted;
         } else {
-          Content = formatted;
+          cellValue = formatted;
         }
       }
 

--- a/packages/edit-table/src/form-input.vue
+++ b/packages/edit-table/src/form-input.vue
@@ -65,24 +65,24 @@ export default {
   },
   computed: {
     text() {
-      let Content = this.data[this.column.id]
+      let Content = this.data[this.column.id];
       let Component = {
         render: h => h('p', null, Content)
-      }
-      
+      };
+
       if (isFunction(this.column.formatter)) {
         const formatted = this.column.formatter(this.data, this.index);
 
         if (isVNode(formatted)) {
-          Component = { render: h => formatted }
+          Component = { render: h => formatted };
         } else if (isObject(formatted)) {
-          Component = formatted
+          Component = formatted;
         } else {
-          Content = formatted
+          Content = formatted;
         }
       }
 
-      return Component
+      return Component;
     },
     inputAttrs() {
       if (isFunction(this.column.el)) {

--- a/packages/edit-table/src/form-input.vue
+++ b/packages/edit-table/src/form-input.vue
@@ -71,7 +71,7 @@ export default {
       };
 
       if (isFunction(this.column.formatter)) {
-        const formatted = this.column.formatter(this.data, this.index);
+        const formatted = this.column.formatter(this.data, this.index, Content);
 
         if (isVNode(formatted)) {
           Component = { render: h => formatted };

--- a/packages/edit-table/src/form-input.vue
+++ b/packages/edit-table/src/form-input.vue
@@ -5,7 +5,7 @@
     v-bind="$attrs"
     :prop="`data.${index}.${column.id}`"
   >
-    <component v-if="readonly" :is="text" />
+    <component v-if="readonly" :is="readonlyComponent" />
     <component
       v-else-if="column.type"
       :is="`el-${column.type}`"
@@ -64,7 +64,7 @@ export default {
     }
   },
   computed: {
-    text() {
+    readonlyComponent() {
       let Content = this.data[this.column.id];
       let Component = {
         render: h => h('p', null, Content)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7414,7 +7414,7 @@ lodash@4.17.14, lodash@^4.0.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.11,
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@^4.2.1:
+lodash@^4.17.15, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -8038,6 +8038,11 @@ nan@^2.10.0, nan@^2.9.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
   integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
 
+nan@^2.13.2:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -8230,7 +8235,30 @@ node-releases@^1.1.3:
   dependencies:
     semver "^5.3.0"
 
-node-sass@^4.11.0, node-sass@^4.8.3:
+node-sass@^4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash "^4.17.15"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.13.2"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
+
+node-sass@^4.8.3:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.11.0.tgz#183faec398e9cbe93ba43362e2768ca988a6369a"
   integrity sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

## Why

close #38 

## Features

- 支持 jsx
- 支持返回自定义组件
- 支持返回字符串

## How

- 解放 `formatter` 被限制在 `P` 元素内
- 根据 `formatter` 返回结果, 判断且处理后, 再整合一个用于展示内容的组件

## Others

node-sass 无法在 node v12.14.x 中运行, 大概说是 OSX 环境不支持, 降到 v11 就好
有反馈说 v12.12.0 还可以