### PR TITLE
fix: 分页数选择器不可被清空

### DIFF
--- a/packages/pagination/src/pagination.js
+++ b/packages/pagination/src/pagination.js
@@ -176,6 +176,7 @@ export default {
               popperClass={ this.$parent.popperClass || '' }
               size="mini"
               on-input={ this.handleChange }
+              clearable={false}
               disabled={ this.$parent.disabled }>
               {
                 this.pageSizes.map(item =>


### PR DESCRIPTION
## Why
因 #35 导致，“分页选择器”不应该可被清除

## How
- 取消 `pagination` 使用到的 `el-select` 的 `clearable` 属性

## Test
before

![image](https://user-images.githubusercontent.com/21327913/75010127-5335bb00-54b7-11ea-81d9-e33e44d14388.png)

after
![image](https://user-images.githubusercontent.com/21327913/75010218-92fca280-54b7-11ea-92f1-90bd50f8665d.png)
