### PR TITLE
fix(input): 修复 textarea 计数器遮挡正文

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -88,6 +88,7 @@
       v-else
       :tabindex="tabindex"
       class="el-textarea__inner"
+      :class="{'el-textarea__count': isWordLimitVisible}"
       @compositionstart="handleCompositionStart"
       @compositionupdate="handleCompositionUpdate"
       @compositionend="handleCompositionEnd"

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -23,6 +23,10 @@
     border-radius: $--input-border-radius;
     transition: $--border-transition-base;
 
+    &.el-textarea__count {
+      padding-bottom: 20px;
+    }
+
     &::placeholder {
       color: $--input-placeholder-color;
     }
@@ -44,6 +48,7 @@
     font-size: 12px;
     bottom: 5px;
     right: 10px;
+    line-height: 1;
   }
 
   @include when(disabled) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

## Why
- textarea 计数器会被 form-item__content 污染样式，导致 line-height 变大，遮挡正文
- 同时加大显示计数器时的 padding-bottom，保证最后一行的可读性

## Test
![textarea](https://user-images.githubusercontent.com/27187946/75136562-0c96c980-5720-11ea-86fe-b657ba04c95a.gif)

