### PR TITLE
fix: switch-enhance 通过 v-model 传入的值不生效

### DIFF
--- a/packages/switch-enhance/src/main.vue
+++ b/packages/switch-enhance/src/main.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="el-switch-enhance">
     <el-switch
-      :class="[{'square': square}, {'inline-text': inlineText}]"
+      :class="{'square': square, 'inline-text': inlineText}"
       v-bind="$attrs"
-      v-model="value"
+      :value="value"
+      @input="onInput"
       v-on="$listeners"
     />
   </div>
@@ -20,12 +21,16 @@ export default {
     inlineText: {
       type: Boolean,
       default: false
+    },
+    value: {
+      type: Boolean,
+      default: false
     }
   },
-  data() {
-    return {
-      value: this.$attrs.value
-    };
+  methods: {
+    onInput(v) {
+      this.$emit('input', v);
+    }
   }
 };
 </script>


### PR DESCRIPTION
## before
https://femessage.github.io/element/#/zh-CN/component/switch-enhance#ji-ben-yong-fa
所有案例的初始值都是 true 但没一个生效

## after
![image](https://user-images.githubusercontent.com/19591950/75752305-6c662380-5d63-11ea-951d-264484031dd2.png)
