### PR TITLE
fix: edit-table 的 indexKeys 应该和 value 同步

### DIFF
--- a/examples/docs/zh-CN/edit-table.md
+++ b/examples/docs/zh-CN/edit-table.md
@@ -528,7 +528,7 @@ export default {
         columns: [
           {
             id: 'id',
-            label: '第几列',
+            label: '第几行',
             type: 'input',
             el: { placeholder: '请输入' },
           },
@@ -543,23 +543,23 @@ export default {
     },
     mounted() {
       this.$refs.form.setOptions('option', [
-        { label: '这是统一选项 A', value: '1' },
-        { label: '这是统一选项 B', value: '2' },
+        { label: '这是统一的选项 A', value: 1 },
+        { label: '这是统一的选项 B', value: 2 },
       ])
     },
     methods: {
       onSyncUpdate() {
         this.data = [
           {
-            id: '第 1 列',
+            id: '第 1 行',
             option: '',
           },
           {
-            id: '第 2 列',
+            id: '第 2 行',
             option: '',
           },
           {
-            id: '第 3 列',
+            id: '第 3 行',
             option: '',
           },
         ]
@@ -570,12 +570,12 @@ export default {
             'option',
             [
               {
-                value: `第 ${i + 1} 列的选项 A`,
-                label: `第 ${i + 1} 列的选项 A`,
+                label: `第 ${i + 1} 行的选项 A`,
+                value: 1,
               },
               {
-                value: `第 ${i + 1} 列的选项 B`,
-                label: `第 ${i + 1} 列的选项 B`,
+                label: `第 ${i + 1} 行的选项 B`,
+                value: 2,
               },
             ],
             i,

--- a/examples/docs/zh-CN/edit-table.md
+++ b/examples/docs/zh-CN/edit-table.md
@@ -511,6 +511,84 @@ export default {
 
 :::
 
+### 异步更新和单独 setOptions
+
+:::demo
+
+```html
+<el-button @click="onSyncUpdate">异步更新</el-button>
+<el-button @click="onSetOptions">SetOptions</el-button>
+<el-edit-table ref="form" :columns="columns" v-model="data"></el-edit-table>
+
+<script>
+  export default {
+    data() {
+      return {
+        data: [],
+        columns: [
+          {
+            id: 'id',
+            label: '第几列',
+            type: 'input',
+            el: { placeholder: '请输入' },
+          },
+          {
+            id: 'option',
+            label: '选项',
+            type: 'select',
+            el: { placeholder: '请选择' },
+          },
+        ],
+      }
+    },
+    mounted() {
+      this.$refs.form.setOptions('option', [
+        { label: '这是统一选项 A', value: '1' },
+        { label: '这是统一选项 B', value: '2' },
+      ])
+    },
+    methods: {
+      onSyncUpdate() {
+        this.data = [
+          {
+            id: '第 1 列',
+            option: '',
+          },
+          {
+            id: '第 2 列',
+            option: '',
+          },
+          {
+            id: '第 3 列',
+            option: '',
+          },
+        ]
+      },
+      onSetOptions() {
+        this.data.forEach((e, i) => {
+          this.$refs.form.setOptions(
+            'option',
+            [
+              {
+                value: `第 ${i + 1} 列的选项 A`,
+                label: `第 ${i + 1} 列的选项 A`,
+              },
+              {
+                value: `第 ${i + 1} 列的选项 B`,
+                label: `第 ${i + 1} 列的选项 B`,
+              },
+            ],
+            i,
+          )
+        })
+      },
+    },
+  }
+</script>
+```
+
+:::
+
 ### Attributes
 
 | 参数      |   说明    |  类型     | 可选值       | 默认值   |

--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,7 @@ if (typeof window !== 'undefined' && window.Vue) {
 }
 
 export default {
-  version: '2.13.0',
+  version: '2.12.0',
   locale: locale.use,
   i18n: locale.i18n,
   install,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

## Why
之前维护 indexKeys 的方式不对，以下几种场景会出现问题：
1. value 异步更新了，但是由于 indexKeys 只会在 beforeMount、addRow、deleteRow 的时候才会更新，所以 setOptions 的时候找不到对应的 index
2. 由于是使用 currentKey 来维护 index，经过用户增加和删除操作后，会出现 indexKeys 为 [1,101,102,103...]的情况，但是使用者 setOptions 的时候，传入的 index 参数是根据当前数组项的索引的，也会导致对不上

## How
1. 去掉 currentKey，统一在 watch value 时重置 indexKeys 和 rowOptionsData
2. 使用 oldValue 记录更新前的 value，然后根据旧的 index 将对应的 rowOptions 放到新的 index 下
