### PR TITLE
fix(edit-table): oldValue 更新问题

### DIFF
--- a/examples/docs/zh-CN/edit-table.md
+++ b/examples/docs/zh-CN/edit-table.md
@@ -516,7 +516,7 @@ export default {
 :::demo
 
 ```html
-<el-button @click="onSyncUpdate">异步更新</el-button>
+<el-button @click="onSyncUpdate">Append</el-button>
 <el-button @click="onSetOptions">SetOptions</el-button>
 <el-edit-table ref="form" :columns="columns" v-model="data"></el-edit-table>
 
@@ -524,7 +524,13 @@ export default {
   export default {
     data() {
       return {
-        data: [],
+        id: 1,
+        data: [
+          {
+            id: `第 1 行`,
+            option: '',
+          },
+        ],
         columns: [
           {
             id: 'id',
@@ -549,20 +555,12 @@ export default {
     },
     methods: {
       onSyncUpdate() {
-        this.data = [
-          {
-            id: '第 1 行',
+        for (let i = 0; i < 3; i++) {
+          this.data.push({
+            id: `第 ${++this.id} 行`,
             option: '',
-          },
-          {
-            id: '第 2 行',
-            option: '',
-          },
-          {
-            id: '第 3 行',
-            option: '',
-          },
-        ]
+          })
+        }
       },
       onSetOptions() {
         this.data.forEach((e, i) => {

--- a/packages/edit-table/src/main.vue
+++ b/packages/edit-table/src/main.vue
@@ -171,6 +171,8 @@ export default {
     value(v) {
       this.resetRowOptionsData(v, this.oldValue);
 
+      this.oldValue = [...v];
+
       this.indexKeys = v.map((_, i) => i);
     }
   },
@@ -207,7 +209,6 @@ export default {
     },
 
     updateValue(value) {
-      this.oldValue = [...this.model.data];
       this.$emit('input', value);
     },
 


### PR DESCRIPTION
fix #61

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

## Why
目前 oldValue 只会在 add 或者 delete 的时候才会更新，但是如果外部更新 vlaue，则不会更新  oldValue，导致 resetRowOptionsData 时找不到旧的 options

## How
在 watch value 变更后 更新 oldValue

## Preview

### before
![2020-06-04 10 50 10](https://user-images.githubusercontent.com/27952659/83711086-d806a800-a654-11ea-86e2-4155c7e9599e.gif)

### after
![2020-06-04 10 57 52](https://user-images.githubusercontent.com/27952659/83711124-eeacff00-a654-11ea-9f23-9e2d8b0a2590.gif)
