### PR TITLE
feat: 为 el-select 添加 extra 插槽

### DIFF
--- a/examples/docs/zh-CN/select.md
+++ b/examples/docs/zh-CN/select.md
@@ -530,9 +530,9 @@
         :value="item.value">
       </el-option>
       <div slot="extra">
-        <el-button type="text" @click="handleRefresh">
-          刷新城市列表
-        </el-button>
+        <el-button type="text" @click="handleRefresh" style="width: 100%;">
+          刷新城市列表
+        </el-button>
       </div>
     </el-select>
   </div>

--- a/examples/docs/zh-CN/select.md
+++ b/examples/docs/zh-CN/select.md
@@ -565,6 +565,7 @@
 |    —    | Option 组件列表 |
 | prefix  | Select 组件头部内容 |
 | empty | 无选项时的列表 |
+| extra | 选项列表下的扩展 |
 
 ### Option Group Attributes
 | 参数      | 说明          | 类型      | 可选值                           | 默认值  |

--- a/examples/docs/zh-CN/select.md
+++ b/examples/docs/zh-CN/select.md
@@ -565,6 +565,7 @@
 |    —    | Option 组件列表 |
 | prefix  | Select 组件头部内容 |
 | empty | 无选项时的列表 |
+| extra | 选项列表底部扩展内容 |
 
 ### Option Group Attributes
 | 参数      | 说明          | 类型      | 可选值                           | 默认值  |

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -122,6 +122,9 @@
           </el-option>
           <slot></slot>
         </el-scrollbar>
+        <template v-if="$slots.extra">
+          <slot name="extra"></slot>
+        </template>
         <template v-if="emptyText && (!allowCreate || loading || (allowCreate && options.length === 0 ))">
           <slot name="empty" v-if="$slots.empty"></slot>
           <p class="el-select-dropdown__empty" v-else>


### PR DESCRIPTION
## Why
如图所示，用户选择成员后，去点击右上角的“成员管理”按钮，浏览器打开一个新的标签页修改成员，修改完后关闭标签页
然后回到这个页面，点击选择列表的“刷新成员列表”按钮，刷新成员列表
![image](https://user-images.githubusercontent.com/11404946/89666367-d1bed180-d90c-11ea-829f-8921e26889ef.png)

## How
选项列表下插入一个插槽
```javascript
<el-select-menu
        ref="popper"
        :append-to-body="popperAppendToBody"
        v-show="visible && emptyText !== false">
        <el-scrollbar
          tag="ul"
          wrap-class="el-select-dropdown__wrap"
          view-class="el-select-dropdown__list"
          ref="scrollbar"
          :class="{ 'is-empty': !allowCreate && query && filteredOptionsCount === 0 }"
          v-show="options.length > 0 && !loading">
          <el-option
            :value="query"
            created
            v-if="showNewOption">
          </el-option>
          <slot></slot>
        </el-scrollbar>
        <template v-if="$slots.extra">
          <slot name="extra"></slot>
        </template>
        <template v-if="emptyText && (!allowCreate || loading || (allowCreate && options.length === 0 ))">
          <slot name="empty" v-if="$slots.empty"></slot>
          <p class="el-select-dropdown__empty" v-else>
            {{ emptyText }}
          </p>
        </template>
```
