### PR TITLE
feat: 提升 date-picker 选择日期用户体验

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -57,7 +57,7 @@
       :name="name && name[0]"
       @input="handleStartInput"
       @change="handleStartChange"
-      @focus="handleFocus"
+      @focus="handleFocus('min')"
       class="el-range-input">
     <slot name="range-separator">
       <span class="el-range-separator">{{ rangeSeparator }}</span>
@@ -72,7 +72,7 @@
       :name="name && name[1]"
       @input="handleEndInput"
       @change="handleEndChange"
-      @focus="handleFocus"
+      @focus="handleFocus('max')"
       class="el-range-input">
     <i
       @click="handleClickIcon"
@@ -401,7 +401,8 @@ export default {
       showClose: false,
       userInput: null,
       valueOnOpen: null, // value when picker opens, used to determine whether to emit change
-      unwatchPickerOptions: null
+      unwatchPickerOptions: null,
+      inputType: null
     };
   },
 
@@ -724,10 +725,11 @@ export default {
       this.userInput = initialValue === '' ? null : initialValue;
     },
 
-    handleFocus() {
+    handleFocus(inputType) {
       const type = this.type;
 
       if (HAVE_TRIGGER_TYPES.indexOf(type) !== -1 && !this.pickerVisible) {
+        this.inputType = inputType;
         this.pickerVisible = true;
       }
       this.$emit('focus', this);
@@ -814,6 +816,7 @@ export default {
 
       this.picker.value = this.parsedValue;
       this.picker.resetView && this.picker.resetView();
+      this.picker.inputType = this.inputType;
 
       this.$nextTick(() => {
         this.picker.adjustSpinners && this.picker.adjustSpinners();


### PR DESCRIPTION
## Why
在日期范围选择框已有值的情况下，希望只修改任意一边的日期，但目前每次修改都需要重新选择开始日期和结束日期，造成用户体验不佳。

## How
![image](https://user-images.githubusercontent.com/27952659/90487309-e0a74e80-e16c-11ea-8bc4-60677932a0e8.png)

## Preview
### before
![2020-08-13 14-03-18](https://user-images.githubusercontent.com/27952659/90100960-588e0700-dd70-11ea-9912-a84e28ce215f.gif)

### after
![2020-08-13 14-03-18-2](https://user-images.githubusercontent.com/27952659/90487479-1fd59f80-e16d-11ea-857b-ca915b7f2086.gif)