### PR TITLE
docs: 更新文档链接

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Please make sure these boxes are checked before submitting your PR, thank you!
 
-* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
+* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/femessage/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/femessage/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/femessage/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/femessage/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
 * [ ] Make sure you are merging your commits to `dev` branch.
 * [ ] Add some descriptions and refer relative issues for you PR.

--- a/FAQ.md
+++ b/FAQ.md
@@ -45,7 +45,7 @@
 <details>
   <summary>你们的文档怎么偷偷更新了？</summary>
   
-  我们只会在 Element 发布新版本时同步更新文档，以体现最新的变化。详细的更新内容可以查看 [changelog](https://github.com/ElemeFE/element/blob/master/CHANGELOG.zh-CN.md)。
+  我们只会在 Element 发布新版本时同步更新文档，以体现最新的变化。详细的更新内容可以查看 [changelog](https://github.com/femessage/element/blob/master/CHANGELOG.zh-CN.md)。
 </details>
 
 <details>
@@ -117,7 +117,7 @@
 <details>
   <summary>When do you update documentations of Element?</summary>
   
-  We update documentations only when a new version of Element is published so that it reflects all the changes introduced in that version. Updated changed can be found in the [changelog](https://github.com/ElemeFE/element/blob/master/CHANGELOG.en-US.md)。
+  We update documentations only when a new version of Element is published so that it reflects all the changes introduced in that version. Updated changed can be found in the [changelog](https://github.com/femessage/element/blob/master/CHANGELOG.en-US.md)。
 </details>
 
 <details>
@@ -191,7 +191,7 @@
 <details>
   <summary>¿Cuando añaden a la documentación de `Element`?</summary>
   
-  Añadamos la documentación con cada versión nueva de `Element` y los cambios reflejan los cambios del software de esa versión. Los cambios actuales y históricos se encuentran [aquí](https://github.com/ElemeFE/element/blob/master/CHANGELOG.en-US.md).
+  Añadamos la documentación con cada versión nueva de `Element` y los cambios reflejan los cambios del software de esa versión. Los cambios actuales y históricos se encuentran [aquí](https://github.com/femessage/element/blob/master/CHANGELOG.en-US.md).
 </details>
 
 <details>

--- a/examples/components/footer.vue
+++ b/examples/components/footer.vue
@@ -3,9 +3,9 @@
     <div class="container">
       <div class="footer-main">
         <h4>{{ langConfig.links }}</h4>
-        <a href="https://github.com/ElemeFE/element" class="footer-main-link" target="_blank">{{ langConfig.repo }}</a>
-        <a href="https://github.com/ElemeFE/element/releases" class="footer-main-link" target="_blank">{{ langConfig.changelog }}</a>
-        <a href="https://github.com/ElemeFE/element/blob/dev/FAQ.md" class="footer-main-link" target="_blank">{{ langConfig.faq }}</a>
+        <a href="https://github.com/femessage/element" class="footer-main-link" target="_blank">{{ langConfig.repo }}</a>
+        <a href="https://github.com/femessage/element/releases" class="footer-main-link" target="_blank">{{ langConfig.changelog }}</a>
+        <a href="https://github.com/femessage/element/blob/dev/FAQ.md" class="footer-main-link" target="_blank">{{ langConfig.faq }}</a>
         <a href="https://github.com/ElementUI/element-starter" class="footer-main-link" target="_blank">{{ langConfig.starter }}</a>
         <a :href="'/#/' + lang + '/component/custom-theme'" class="footer-main-link" target="_blank">{{ langConfig.theme }}</a>
         <a href="https://github.com/elemefe/element-react" class="footer-main-link" target="_blank">Element-React</a>
@@ -14,8 +14,8 @@
       <div class="footer-main">
         <h4>{{ langConfig.community }}</h4>
         <a :href="gitterLink" class="footer-main-link" target="_blank">{{ langConfig.gitter }}</a>
-        <a href="https://github.com/ElemeFE/element/issues" class="footer-main-link" target="_blank">{{ langConfig.feedback }}</a>
-        <a :href="`https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.${ lang }.md`" class="footer-main-link" target="_blank">{{ langConfig.contribution }}</a>
+        <a href="https://github.com/femessage/element/issues" class="footer-main-link" target="_blank">{{ langConfig.feedback }}</a>
+        <a :href="`https://github.com/femessage/element/blob/master/.github/CONTRIBUTING.${ lang }.md`" class="footer-main-link" target="_blank">{{ langConfig.contribution }}</a>
         <a href="https://segmentfault.com/t/element-ui" class="footer-main-link" target="_blank">SegmentFault</a>
         <a href="https://github.com/ElementUI/awesome-element" class="footer-main-link" target="_blank">Awesome Element</a>
       </div>
@@ -31,7 +31,7 @@
           <img src="../assets/images/qrcode.png" alt="">
         </el-popover>
         <i class="doc-icon-weixin elementdoc" v-popover:weixin></i>
-        <a href="https://github.com/elemefe" target="_blank">
+        <a href="https://github.com/femessage" target="_blank">
           <i class="doc-icon-github elementdoc"></i>
         </a>
         <a :href="gitterLink" target="_blank">

--- a/examples/components/side-nav.vue
+++ b/examples/components/side-nav.vue
@@ -288,7 +288,7 @@
           if (xhr.readyState === 4 && xhr.status === 200) {
             const {data: navs} = JSON.parse(xhr.responseText);
             this.femessageNavs = navs.map(nav => {
-              nav.url = `https://static.deepexi.top/serverless-console/index.html#/material/${nav.repoName}`;
+              nav.url = `https://frontend-infra.deepexi.com/home/index.html#/material/${nav.repoName}`;
               return nav;
             }).filter(nav => nav.lib && nav.lib.indexOf('element') > -1);
           }

--- a/examples/docs/en-US/custom-theme.md
+++ b/examples/docs/en-US/custom-theme.md
@@ -21,15 +21,15 @@ The above website enables you to preview theme of a new theme color in real-time
 $--color-primary: teal;
 
 /* icon font path, required */
-$--font-path: '~element-ui/lib/theme-chalk/fonts';
+$--font-path: '~@femessage/element-ui/lib/theme-chalk/fonts';
 
-@import "~element-ui/packages/theme-chalk/src/index";
+@import "~@femessage/element-ui/packages/theme-chalk/src/index";
 ```
 
 Then in the entry file of your project, import this style file instead of Element's built CSS:
 ```JS
 import Vue from 'vue'
-import Element from 'element-ui'
+import Element from '@femessage/element-ui'
 import './element-variables.scss'
 
 Vue.use(Element)
@@ -107,7 +107,7 @@ Importing your own theme is just like importing the default theme, only this tim
 
 ```javascript
 import '../theme/index.css'
-import ElementUI from 'element-ui'
+import ElementUI from '@femessage/element-ui'
 import Vue from 'vue'
 
 Vue.use(ElementUI)

--- a/examples/docs/en-US/i18n.md
+++ b/examples/docs/en-US/i18n.md
@@ -4,8 +4,8 @@ The default language of Element is Chinese. If you wish to use another language,
 
 ```javascript
 import Vue from 'vue'
-import ElementUI from 'element-ui'
-import locale from 'element-ui/lib/locale/lang/en'
+import ElementUI from '@femessage/element-ui'
+import locale from '@femessage/element-ui/lib/locale/lang/en'
 
 Vue.use(ElementUI, { locale })
 ```
@@ -14,9 +14,9 @@ Or if you are importing Element on demand:
 
 ```javascript
 import Vue from 'vue'
-import { Button, Select } from 'element-ui'
-import lang from 'element-ui/lib/locale/lang/en'
-import locale from 'element-ui/lib/locale'
+import { Button, Select } from '@femessage/element-ui'
+import lang from '@femessage/element-ui/lib/locale/lang/en'
+import locale from '@femessage/element-ui/lib/locale'
 
 // configure language
 locale.use(lang)
@@ -32,7 +32,7 @@ webpack.config.js
 ```javascript
 {
   plugins: [
-    new webpack.NormalModuleReplacementPlugin(/element-ui[\/\\]lib[\/\\]locale[\/\\]lang[\/\\]zh-CN/, 'element-ui/lib/locale/lang/en')
+    new webpack.NormalModuleReplacementPlugin(/@femessage[\/\\]element-ui[\/\\]lib[\/\\]locale[\/\\]lang[\/\\]zh-CN/, '@femessage/element-ui/lib/locale/lang/en')
   ]
 }
 ```
@@ -44,9 +44,9 @@ Element is compatible with [vue-i18n@5.x](https://github.com/kazupon/vue-i18n), 
 ```javascript
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
-import Element from 'element-ui'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import Element from '@femessage/element-ui'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(VueI18n)
 Vue.use(Element)
@@ -61,9 +61,9 @@ Element may not be compatible with i18n plugins other than vue-i18n, but you can
 
 ```javascript
 import Vue from 'vue'
-import Element from 'element-ui'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import Element from '@femessage/element-ui'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(Element, {
   i18n: function (path, options) {
@@ -78,10 +78,10 @@ You need to manually handle it for compatibility with `6.x`.
 
 ```javascript
 import Vue from 'vue'
-import Element from 'element-ui'
+import Element from '@femessage/element-ui'
 import VueI18n from 'vue-i18n'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(VueI18n)
 
@@ -115,9 +115,9 @@ import Vue from 'vue'
 import DatePicker from 'element/lib/date-picker'
 import VueI18n from 'vue-i18n'
 
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
-import ElementLocale from 'element-ui/lib/locale'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
+import ElementLocale from '@femessage/element-ui/lib/locale'
 
 Vue.use(VueI18n)
 Vue.use(DatePicker)
@@ -145,8 +145,8 @@ ElementLocale.i18n((key, value) => i18n.t(key, value))
 
 ```html
 <script src="//unpkg.com/vue"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="//unpkg.com/@femessage/element-ui"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   ELEMENT.locale(ELEMENT.lang.en)
@@ -158,9 +158,9 @@ Compatible with `vue-i18n`
 ```html
 <script src="//unpkg.com/vue"></script>
 <script src="//unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/zh-CN.js"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="//unpkg.com/@femessage/element-ui"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/zh-CN.js"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   Vue.locale('en', ELEMENT.lang.en)
@@ -223,4 +223,4 @@ Currently Element ships with the following languages:
   <li>Esperanto (eo)</li>
 </ul>
 
-If your target language is not included, you are more than welcome to contribute: just add another language config [here](https://github.com/ElemeFE/element/tree/dev/src/locale/lang) and create a pull request.
+If your target language is not included, you are more than welcome to contribute: just add another language config [here](https://github.com/femessage/element/tree/dev/src/locale/lang) and create a pull request.

--- a/examples/docs/en-US/input.md
+++ b/examples/docs/en-US/input.md
@@ -355,7 +355,7 @@ You can get some recommended tips based on the current input.
       loadAll() {
         return [
           { "value": "vue", "link": "https://github.com/vuejs/vue" },
-          { "value": "element", "link": "https://github.com/ElemeFE/element" },
+          { "value": "element", "link": "https://github.com/femessage/element" },
           { "value": "cooking", "link": "https://github.com/ElemeFE/cooking" },
           { "value": "mint-ui", "link": "https://github.com/ElemeFE/mint-ui" },
           { "value": "vuex", "link": "https://github.com/vuejs/vuex" },
@@ -439,7 +439,7 @@ Customize how suggestions are displayed.
       loadAll() {
         return [
           { "value": "vue", "link": "https://github.com/vuejs/vue" },
-          { "value": "element", "link": "https://github.com/ElemeFE/element" },
+          { "value": "element", "link": "https://github.com/femessage/element" },
           { "value": "cooking", "link": "https://github.com/ElemeFE/cooking" },
           { "value": "mint-ui", "link": "https://github.com/ElemeFE/mint-ui" },
           { "value": "vuex", "link": "https://github.com/vuejs/vuex" },
@@ -487,7 +487,7 @@ Search data from server-side.
       loadAll() {
         return [
           { "value": "vue", "link": "https://github.com/vuejs/vue" },
-          { "value": "element", "link": "https://github.com/ElemeFE/element" },
+          { "value": "element", "link": "https://github.com/femessage/element" },
           { "value": "cooking", "link": "https://github.com/ElemeFE/cooking" },
           { "value": "mint-ui", "link": "https://github.com/ElemeFE/mint-ui" },
           { "value": "vuex", "link": "https://github.com/vuejs/vuex" },

--- a/examples/docs/en-US/installation.md
+++ b/examples/docs/en-US/installation.md
@@ -10,13 +10,13 @@ npm i element-ui -S
 
 ### CDN
 
-Get the latest version from [unpkg.com/element-ui](https://unpkg.com/element-ui/) , and import JavaScript and CSS file in your page.
+Get the latest version from [unpkg.com/element-ui](https://unpkg.com/@femessage/element-ui/) , and import JavaScript and CSS file in your page.
 
 ```html
 <!-- import CSS -->
-<link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-chalk/index.css">
+<link rel="stylesheet" href="https://unpkg.com/@femessage/element-ui/lib/theme-chalk/index.css">
 <!-- import JavaScript -->
-<script src="https://unpkg.com/element-ui/lib/index.js"></script>
+<script src="https://unpkg.com/@femessage/element-ui/lib/index.js"></script>
 ```
 
 :::tip

--- a/examples/docs/en-US/layout.md
+++ b/examples/docs/en-US/layout.md
@@ -315,7 +315,7 @@ Taking example by Bootstrap's responsive design, five breakpoints are preset: xs
 Additionally, Element provides a series of classes for hiding elements under certain conditions. These classes can be added to any DOM elements or custom components. You need to import the following CSS file to use these classes:
 
 ```js
-import 'element-ui/lib/theme-chalk/display.css';
+import '@femessage/element-ui/lib/theme-chalk/display.css';
 ```
 
 The classes are:

--- a/examples/docs/en-US/loading.md
+++ b/examples/docs/en-US/loading.md
@@ -173,7 +173,7 @@ Show a full screen animation while loading data.
 ### Service
 You can also invoke Loading with a service. Import Loading service:
 ```javascript
-import { Loading } from 'element-ui';
+import { Loading } from '@femessage/element-ui';
 ```
 Invoke it:
 ```javascript

--- a/examples/docs/en-US/message-box.md
+++ b/examples/docs/en-US/message-box.md
@@ -165,7 +165,7 @@ Can be customized to show various content.
 :::
 
 :::tip
-The content of MessageBox can be `VNode`, allowing us to pass custom components. When opening the MessageBox, Vue compares new `VNode` with old `VNode`, then figures out how to efficiently update the UI, so the components may not be completely re-rendered ([#8931](https://github.com/ElemeFE/element/issues/8931)). In this case, you can add a unique key to `VNode` each time MessageBox opens: [example](https://jsfiddle.net/zhiyang/ezmhq2ef).
+The content of MessageBox can be `VNode`, allowing us to pass custom components. When opening the MessageBox, Vue compares new `VNode` with old `VNode`, then figures out how to efficiently update the UI, so the components may not be completely re-rendered ([#8931](https://github.com/femessage/element/issues/8931)). In this case, you can add a unique key to `VNode` each time MessageBox opens: [example](https://jsfiddle.net/zhiyang/ezmhq2ef).
 :::
 
 ### Use HTML String
@@ -288,7 +288,7 @@ If Element is fully imported, it will add the following global methods for Vue.p
 If you prefer importing `MessageBox` on demand:
 
 ```javascript
-import { MessageBox } from 'element-ui';
+import { MessageBox } from '@femessage/element-ui';
 ```
 
 The corresponding methods are: `MessageBox`, `MessageBox.alert`, `MessageBox.confirm` and `MessageBox.prompt`. The parameters are the same as above.

--- a/examples/docs/en-US/message.md
+++ b/examples/docs/en-US/message.md
@@ -193,7 +193,7 @@ Element has added a global method `$message` for Vue.prototype. So in a vue inst
 Import `Message`:
 
 ```javascript
-import { Message } from 'element-ui';
+import { Message } from '@femessage/element-ui';
 ```
 
 In this case you should call `Message(options)`. We have also registered methods for different types, e.g. `Message.success(options)`. You can call `Message.closeAll()` to manually close all the instances.

--- a/examples/docs/en-US/notification.md
+++ b/examples/docs/en-US/notification.md
@@ -282,7 +282,7 @@ Element has added a global method `$notify` for Vue.prototype. So in a vue insta
 Import `Notification`:
 
 ```javascript
-import { Notification } from 'element-ui';
+import { Notification } from '@femessage/element-ui';
 ```
 
 In this case you should call `Notification(options)`. We have also registered methods for different types, e.g. `Notification.success(options)`. You can call `Notification.closeAll()` to manually close all the instances.

--- a/examples/docs/en-US/quickstart.md
+++ b/examples/docs/en-US/quickstart.md
@@ -22,8 +22,8 @@ In main.js:
 
 ```javascript
 import Vue from 'vue';
-import ElementUI from 'element-ui';
-import 'element-ui/lib/theme-chalk/index.css';
+import ElementUI from '@femessage/element-ui';
+import '@femessage/element-ui/lib/theme-chalk/index.css';
 import App from './App.vue';
 
 Vue.use(ElementUI);
@@ -67,7 +67,7 @@ Next, if you need Button and Select, edit main.js:
 
 ```javascript
 import Vue from 'vue';
-import { Button, Select } from 'element-ui';
+import { Button, Select } from '@femessage/element-ui';
 import App from './App.vue';
 
 Vue.component(Button.name, Button);
@@ -83,7 +83,7 @@ new Vue({
 });
 ```
 
-Full example (Component list reference [components.json](https://github.com/ElemeFE/element/blob/master/components.json))
+Full example (Component list reference [components.json](https://github.com/femessage/element/blob/master/components.json))
 
 ```javascript
 import Vue from 'vue';
@@ -165,7 +165,7 @@ import {
   MessageBox,
   Message,
   Notification
-} from 'element-ui';
+} from '@femessage/element-ui';
 
 Vue.use(Pagination);
 Vue.use(Dialog);
@@ -260,7 +260,7 @@ Fully import Element：
 
 ```js
 import Vue from 'vue';
-import Element from 'element-ui';
+import Element from '@femessage/element-ui';
 Vue.use(Element, { size: 'small', zIndex: 3000 });
 ```
 
@@ -268,7 +268,7 @@ Partial import Element：
 
 ```js
 import Vue from 'vue';
-import { Button } from 'element-ui';
+import { Button } from '@femessage/element-ui';
 
 Vue.prototype.$ELEMENT = { size: 'small', zIndex: 3000 };
 Vue.use(Button);

--- a/examples/docs/en-US/transition.md
+++ b/examples/docs/en-US/transition.md
@@ -146,9 +146,9 @@ For collapse effect, use the `el-collapse-transition` component.
 
 ```js
 // fade/zoom
-import 'element-ui/lib/theme-chalk/base.css';
+import '@femessage/element-ui/lib/theme-chalk/base.css';
 // collapse
-import CollapseTransition from 'element-ui/lib/transitions/collapse-transition';
+import CollapseTransition from '@femessage/element-ui/lib/transitions/collapse-transition';
 import Vue from 'vue'
 
 Vue.component(CollapseTransition.name, CollapseTransition)

--- a/examples/docs/es/custom-theme.md
+++ b/examples/docs/es/custom-theme.md
@@ -21,15 +21,15 @@ Este sitio, le permitirá obtener una vista previa del tema con un nuevo color e
 $--color-primary: teal;
 
 /* Ubicación de la fuente, obligatoria */
-$--font-path: '~element-ui/lib/theme-chalk/fonts';
+$--font-path: '~@femessage/element-ui/lib/theme-chalk/fonts';
 
-@import "~element-ui/packages/theme-chalk/src/index";
+@import "~@femessage/element-ui/packages/theme-chalk/src/index";
 ```
 
 Entonces, en el archivo principal del proyecto, importe este archivo de estilos en lugar de los estilos de Element:
 ```JS
 import Vue from 'vue'
-import Element from 'element-ui'
+import Element from '@femessage/element-ui'
 import './element-variables.scss'
 
 Vue.use(Element)
@@ -108,7 +108,7 @@ Importing your own theme is just like importing the default theme, only this tim
 
 ```javascript
 import '../theme/index.css'
-import ElementUI from 'element-ui'
+import ElementUI from '@femessage/element-ui'
 import Vue from 'vue'
 
 Vue.use(ElementUI)

--- a/examples/docs/es/i18n.md
+++ b/examples/docs/es/i18n.md
@@ -4,8 +4,8 @@ El idioma predeterminado de Element es el chino. Si se desea utilizar otro idiom
 
 ```javascript
 import Vue from 'vue'
-import ElementUI from 'element-ui'
-import locale from 'element-ui/lib/locale/lang/en'
+import ElementUI from '@femessage/element-ui'
+import locale from '@femessage/element-ui/lib/locale/lang/en'
 
 Vue.use(ElementUI, { locale })
 ```
@@ -14,9 +14,9 @@ O si está importando Element a petición:
 
 ```javascript
 import Vue from 'vue'
-import { Button, Select } from 'element-ui'
-import lang from 'element-ui/lib/locale/lang/en'
-import locale from 'element-ui/lib/locale'
+import { Button, Select } from '@femessage/element-ui'
+import lang from '@femessage/element-ui/lib/locale/lang/en'
+import locale from '@femessage/element-ui/lib/locale'
 
 // configure language
 locale.use(lang)
@@ -32,7 +32,7 @@ webpack.config.js
 ```javascript
 {
   plugins: [
-    new webpack.NormalModuleReplacementPlugin(/element-ui[\/\\]lib[\/\\]locale[\/\\]lang[\/\\]zh-CN/, 'element-ui/lib/locale/lang/en')
+    new webpack.NormalModuleReplacementPlugin(/@femessage[\/\\]element-ui[\/\\]lib[\/\\]locale[\/\\]lang[\/\\]zh-CN/, '@femessage/element-ui/lib/locale/lang/en')
   ]
 }
 ```
@@ -44,9 +44,9 @@ Element es compatible con [vue-i18n@5.x](https://github.com/kazupon/vue-i18n), l
 ```javascript
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
-import Element from 'element-ui'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import Element from '@femessage/element-ui'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(VueI18n)
 Vue.use(Element)
@@ -61,9 +61,9 @@ Es posible que Element no sea compatible con otros plugins i18n que no sean vue-
 
 ```javascript
 import Vue from 'vue'
-import Element from 'element-ui'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import Element from '@femessage/element-ui'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(Element, {
   i18n: function (path, options) {
@@ -78,10 +78,10 @@ Necesita manejarlo manualmente para ser compatible con `6.x`.
 
 ```javascript
 import Vue from 'vue'
-import Element from 'element-ui'
+import Element from '@femessage/element-ui'
 import VueI18n from 'vue-i18n'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(VueI18n)
 
@@ -115,9 +115,9 @@ import Vue from 'vue'
 import DatePicker from 'element/lib/date-picker'
 import VueI18n from 'vue-i18n'
 
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
-import ElementLocale from 'element-ui/lib/locale'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
+import ElementLocale from '@femessage/element-ui/lib/locale'
 
 Vue.use(VueI18n)
 Vue.use(DatePicker)
@@ -145,8 +145,8 @@ ElementLocale.i18n((key, value) => i18n.t(key, value))
 
 ```html
 <script src="//unpkg.com/vue"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="//unpkg.com/@femessage/element-ui"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   ELEMENT.locale(ELEMENT.lang.en)
@@ -158,9 +158,9 @@ Compatible con `vue-i18n`
 ```html
 <script src="//unpkg.com/vue"></script>
 <script src="//unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/zh-CN.js"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="//unpkg.com/@femessage/element-ui"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/zh-CN.js"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   Vue.locale('en', ELEMENT.lang.en)
@@ -223,4 +223,4 @@ Actualmente Element está disponible en los siguientes idiomas:
   <li>Esperanto (eo)</li>
 </ul>
 
-Si su idioma de destino no está incluido, puede contribuir: simplemente añada  [aqui](https://github.com/ElemeFE/element/tree/dev/src/locale/lang) otra configuración de idioma y cree un pull request.
+Si su idioma de destino no está incluido, puede contribuir: simplemente añada  [aqui](https://github.com/femessage/element/tree/dev/src/locale/lang) otra configuración de idioma y cree un pull request.

--- a/examples/docs/es/input.md
+++ b/examples/docs/es/input.md
@@ -364,7 +364,7 @@ Puede obtener algunas sugerencias basadas en la entrada actual.
       loadAll() {
         return [
           { "value": "vue", "link": "https://github.com/vuejs/vue" },
-          { "value": "element", "link": "https://github.com/ElemeFE/element" },
+          { "value": "element", "link": "https://github.com/femessage/element" },
           { "value": "cooking", "link": "https://github.com/ElemeFE/cooking" },
           { "value": "mint-ui", "link": "https://github.com/ElemeFE/mint-ui" },
           { "value": "vuex", "link": "https://github.com/vuejs/vuex" },
@@ -450,7 +450,7 @@ Personalice cómo se muestran las sugerencias.
       loadAll() {
         return [
           { "value": "vue", "link": "https://github.com/vuejs/vue" },
-          { "value": "element", "link": "https://github.com/ElemeFE/element" },
+          { "value": "element", "link": "https://github.com/femessage/element" },
           { "value": "cooking", "link": "https://github.com/ElemeFE/cooking" },
           { "value": "mint-ui", "link": "https://github.com/ElemeFE/mint-ui" },
           { "value": "vuex", "link": "https://github.com/vuejs/vuex" },
@@ -500,7 +500,7 @@ Búsqueda de datos desde el servidor.
       loadAll() {
         return [
           { "value": "vue", "link": "https://github.com/vuejs/vue" },
-          { "value": "element", "link": "https://github.com/ElemeFE/element" },
+          { "value": "element", "link": "https://github.com/femessage/element" },
           { "value": "cooking", "link": "https://github.com/ElemeFE/cooking" },
           { "value": "mint-ui", "link": "https://github.com/ElemeFE/mint-ui" },
           { "value": "vuex", "link": "https://github.com/vuejs/vuex" },

--- a/examples/docs/es/installation.md
+++ b/examples/docs/es/installation.md
@@ -10,13 +10,13 @@ npm i element-ui -S
 
 ### CDN
 
-Obtenga la última versión desde [unpkg.com/element-ui](https://unpkg.com/element-ui/) , e importe el JavaScript y los archivos CSS en su página.
+Obtenga la última versión desde [unpkg.com/element-ui](https://unpkg.com/@femessage/element-ui/) , e importe el JavaScript y los archivos CSS en su página.
 
 ```html
 <!-- import CSS -->
-<link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-chalk/index.css">
+<link rel="stylesheet" href="https://unpkg.com/@femessage/element-ui/lib/theme-chalk/index.css">
 <!-- import JavaScript -->
-<script src="https://unpkg.com/element-ui/lib/index.js"></script>
+<script src="https://unpkg.com/@femessage/element-ui/lib/index.js"></script>
 ```
 
 ##Tip

--- a/examples/docs/es/layout.md
+++ b/examples/docs/es/layout.md
@@ -315,7 +315,7 @@ Tomando el ejemplo de Bootstrap responsive design, existen 5 breakpoints: xs, sm
 Adicionalmente, Element provee una serie de clases para ocultar elementos dadas ciertas condiciones. Estas clases pueden se agregadas a cualquier elemento del DOM o un elemento propio. Necesita importar el siguiente archivo CSS para usar estas clases:
 
 ```js
-import 'element-ui/lib/theme-chalk/display.css';
+import '@femessage/element-ui/lib/theme-chalk/display.css';
 ```
 
 Las clases son:

--- a/examples/docs/es/loading.md
+++ b/examples/docs/es/loading.md
@@ -175,7 +175,7 @@ Muestra una animación de pantalla completa mientras se cargan los datos
 Puede invocar el componente con un servicio. Importe el servicio:
 
 ```javascript
-import { Loading } from 'element-ui';
+import { Loading } from '@femessage/element-ui';
 ```
 Invocar:
 ```javascript

--- a/examples/docs/es/message-box.md
+++ b/examples/docs/es/message-box.md
@@ -167,7 +167,7 @@ Puede ser personalizado para mostrar diversos contenidos.
 
 :::tip
 
-El contenido de MessageBox puede ser `VNode`, permitiéndonos pasar componentes personalizados. Al abrir el MessageBox, Vue compara el nuevo `VNode` con el viejo `VNode`, y luego averigua cómo actualizar eficientemente la interfaz de usuario, de modo que es posible que los componentes no se vuelvan a procesar completamente ([#8931](https://github.com/ElemeFE/element/issues/8931)). En este caso, se puede añadir una clave única a `VNode` cada vez que se abre MessageBox: [ejemplo](https://jsfiddle.net/zhiyang/ezmhq2ef).
+El contenido de MessageBox puede ser `VNode`, permitiéndonos pasar componentes personalizados. Al abrir el MessageBox, Vue compara el nuevo `VNode` con el viejo `VNode`, y luego averigua cómo actualizar eficientemente la interfaz de usuario, de modo que es posible que los componentes no se vuelvan a procesar completamente ([#8931](https://github.com/femessage/element/issues/8931)). En este caso, se puede añadir una clave única a `VNode` cada vez que se abre MessageBox: [ejemplo](https://jsfiddle.net/zhiyang/ezmhq2ef).
 
 :::
 
@@ -292,7 +292,7 @@ Si Element fue importado completamente, agregara los siguientes métodos globale
 Si prefieres importar `MessageBox` cuando lo necesites (on demand):
 
 ```javascript
-import { MessageBox } from 'element-ui';
+import { MessageBox } from '@femessage/element-ui';
 ```
 
 Los métodos correspondientes: `MessageBox`, `MessageBox.alert`, `MessageBox.confirm` y `MessageBox.prompt`. Los parámetros son los mismos que los anteriores.

--- a/examples/docs/es/message.md
+++ b/examples/docs/es/message.md
@@ -193,7 +193,7 @@ Element ha agregado un método global llamado `$message` para Vue.prototype. Ent
 Import `Message`:
 
 ```javascript
-import { Message } from 'element-ui';
+import { Message } from '@femessage/element-ui';
 ```
 
 En este caso debería llamar al método `Message(options)`. También se han registrado métodos para los diferentes tipos, e.g. `Message.success(options)`. Puede llamar al método `Message.closeAll()` para cerrar manualmente todas las instancias.

--- a/examples/docs/es/notification.md
+++ b/examples/docs/es/notification.md
@@ -289,7 +289,7 @@ Element ha añadido un método global `$notify` para Vue.prototype. Así que en 
 Importar `Notification`:
 
 ```javascript
-import { Notification } from 'element-ui';
+import { Notification } from '@femessage/element-ui';
 ```
 
 En este caso, debe llamar a `Notification(options)`. También se han registrado métodos para diferentes tipos, e.j. `Notification.success(options)`. Puede llamar al método `Notification.closeAll()` para cerrar manualmente todas las instancias.

--- a/examples/docs/es/quickstart.md
+++ b/examples/docs/es/quickstart.md
@@ -22,8 +22,8 @@ En main.js:
 
 ```javascript
 import Vue from 'vue';
-import ElementUI from 'element-ui';
-import 'element-ui/lib/theme-chalk/index.css';
+import ElementUI from '@femessage/element-ui';
+import '@femessage/element-ui/lib/theme-chalk/index.css';
 import App from './App.vue';
 
 Vue.use(ElementUI);
@@ -67,7 +67,7 @@ Luego, si necesita Button y Select, edite main.js:
 
 ```javascript
 import Vue from 'vue';
-import { Button, Select } from 'element-ui';
+import { Button, Select } from '@femessage/element-ui';
 import App from './App.vue';
 
 Vue.component(Button.name, Button);
@@ -83,7 +83,7 @@ new Vue({
 });
 ```
 
-Ejemplo completo (Referencia completa de componentes [components.json](https://github.com/ElemeFE/element/blob/master/components.json))
+Ejemplo completo (Referencia completa de componentes [components.json](https://github.com/femessage/element/blob/master/components.json))
 
 ```javascript
 import Vue from 'vue';
@@ -165,7 +165,7 @@ import {
   MessageBox,
   Message,
   Notification
-} from 'element-ui';
+} from '@femessage/element-ui';
 
 Vue.use(Pagination);
 Vue.use(Dialog);
@@ -262,7 +262,7 @@ Importando Element completamente：
 
 ```js
 import Vue from 'vue';
-import Element from 'element-ui';
+import Element from '@femessage/element-ui';
 Vue.use(Element, { size: 'small', zIndex: 3000 });
 ```
 
@@ -270,7 +270,7 @@ Importando Element parcialmente：
 
 ```js
 import Vue from 'vue';
-import { Button } from 'element-ui';
+import { Button } from '@femessage/element-ui';
 
 Vue.prototype.$ELEMENT = { size: 'small', zIndex: 3000 };
 Vue.use(Button);

--- a/examples/docs/es/transition.md
+++ b/examples/docs/es/transition.md
@@ -145,9 +145,9 @@ Para efectos de colapsado usar el componente `el-collapse-transition`.
 
 ```js
 // fade/zoom
-import 'element-ui/lib/theme-chalk/base.css';
+import '@femessage/element-ui/lib/theme-chalk/base.css';
 // colapsar
-import CollapseTransition from 'element-ui/lib/transitions/collapse-transition';
+import CollapseTransition from '@femessage/element-ui/lib/transitions/collapse-transition';
 import Vue from 'vue'
 
 Vue.component(CollapseTransition.name, CollapseTransition)

--- a/examples/docs/fr-FR/custom-theme.md
+++ b/examples/docs/fr-FR/custom-theme.md
@@ -21,15 +21,15 @@ Le site précédent vous permet de visualiser et de télécharger un nouveau th�
 $--color-primary: teal;
 
 /* chemin vers le fichier de police, requis */
-$--font-path: '~element-ui/lib/theme-chalk/fonts';
+$--font-path: '~@femessage/element-ui/lib/theme-chalk/fonts';
 
-@import "~element-ui/packages/theme-chalk/src/index";
+@import "~@femessage/element-ui/packages/theme-chalk/src/index";
 ```
 
 Puis dans le fichier d'entrée, importez ce style au lieu de celui d'Element:
 ```JS
 import Vue from 'vue'
-import Element from 'element-ui'
+import Element from '@femessage/element-ui'
 import './element-variables.scss'
 
 Vue.use(Element)
@@ -109,7 +109,7 @@ Importing your own theme is just like importing the default theme, only this tim
 
 ```javascript
 import '../theme/index.css'
-import ElementUI from 'element-ui'
+import ElementUI from '@femessage/element-ui'
 import Vue from 'vue'
 
 Vue.use(ElementUI)

--- a/examples/docs/fr-FR/i18n.md
+++ b/examples/docs/fr-FR/i18n.md
@@ -4,8 +4,8 @@ La langue par défaut d'Element est le Chinois. Si vous souhaitez utiliser une a
 
 ```javascript
 import Vue from 'vue'
-import ElementUI from 'element-ui'
-import locale from 'element-ui/lib/locale/lang/en'
+import ElementUI from '@femessage/element-ui'
+import locale from '@femessage/element-ui/lib/locale/lang/en'
 
 Vue.use(ElementUI, { locale })
 ```
@@ -14,9 +14,9 @@ Ou si vous importez Element à la demande:
 
 ```javascript
 import Vue from 'vue'
-import { Button, Select } from 'element-ui'
-import lang from 'element-ui/lib/locale/lang/en'
-import locale from 'element-ui/lib/locale'
+import { Button, Select } from '@femessage/element-ui'
+import lang from '@femessage/element-ui/lib/locale/lang/en'
+import locale from '@femessage/element-ui/lib/locale'
 
 // configure la langue
 locale.use(lang)
@@ -32,7 +32,7 @@ webpack.config.js
 ```javascript
 {
   plugins: [
-    new webpack.NormalModuleReplacementPlugin(/element-ui[\/\\]lib[\/\\]locale[\/\\]lang[\/\\]zh-CN/, 'element-ui/lib/locale/lang/en')
+    new webpack.NormalModuleReplacementPlugin(/@femessage[\/\\]element-ui[\/\\]lib[\/\\]locale[\/\\]lang[\/\\]zh-CN/, '@femessage/element-ui/lib/locale/lang/en')
   ]
 }
 ```
@@ -44,9 +44,9 @@ Element est compatible avec [vue-i18n@5.x](https://github.com/kazupon/vue-i18n),
 ```javascript
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
-import Element from 'element-ui'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import Element from '@femessage/element-ui'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(VueI18n)
 Vue.use(Element)
@@ -62,9 +62,9 @@ Element n'est pas forcément compatible avec d'autres plugins i18n que vue-i18n,
 
 ```javascript
 import Vue from 'vue'
-import Element from 'element-ui'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import Element from '@femessage/element-ui'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(Element, {
   i18n: function (path, options) {
@@ -79,10 +79,10 @@ Vous devrez le configurer manuellement pour la compatibilité avec `6.x`.
 
 ```javascript
 import Vue from 'vue'
-import Element from 'element-ui'
+import Element from '@femessage/element-ui'
 import VueI18n from 'vue-i18n'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(VueI18n)
 
@@ -117,9 +117,9 @@ import Vue from 'vue'
 import DatePicker from 'element/lib/date-picker'
 import VueI18n from 'vue-i18n'
 
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
-import ElementLocale from 'element-ui/lib/locale'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
+import ElementLocale from '@femessage/element-ui/lib/locale'
 
 Vue.use(VueI18n)
 Vue.use(DatePicker)
@@ -148,8 +148,8 @@ ElementLocale.i18n((key, value) => i18n.t(key, value))
 
 ```html
 <script src="//unpkg.com/vue"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="//unpkg.com/@femessage/element-ui"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   ELEMENT.locale(ELEMENT.lang.en)
@@ -161,9 +161,9 @@ Compatible avec `vue-i18n`
 ```html
 <script src="//unpkg.com/vue"></script>
 <script src="//unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/zh-CN.js"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="//unpkg.com/@femessage/element-ui"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/zh-CN.js"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   Vue.locale('en', ELEMENT.lang.en)
@@ -226,4 +226,4 @@ Actuellement, Element supporte les langues suivantes:
   <li>Espéranto (eo)</li>
 </ul>
 
-Si votre langue n'apparaît pas dans la liste, n'hésitez pas a contribuer: ajoutez simplement un fichier de configuration [ici](https://github.com/ElemeFE/element/tree/dev/src/locale/lang) et créez une pull request.
+Si votre langue n'apparaît pas dans la liste, n'hésitez pas a contribuer: ajoutez simplement un fichier de configuration [ici](https://github.com/femessage/element/tree/dev/src/locale/lang) et créez une pull request.

--- a/examples/docs/fr-FR/input.md
+++ b/examples/docs/fr-FR/input.md
@@ -354,7 +354,7 @@ Vous pouvez obtenir de l'aide ou des suggestions basées sur ce que vous entrez.
       loadAll() {
         return [
           { "value": "vue", "link": "https://github.com/vuejs/vue" },
-          { "value": "element", "link": "https://github.com/ElemeFE/element" },
+          { "value": "element", "link": "https://github.com/femessage/element" },
           { "value": "cooking", "link": "https://github.com/ElemeFE/cooking" },
           { "value": "mint-ui", "link": "https://github.com/ElemeFE/mint-ui" },
           { "value": "vuex", "link": "https://github.com/vuejs/vuex" },
@@ -438,7 +438,7 @@ Vous pouvez personnaliser la manière dont les suggestions sont affichées.
       loadAll() {
         return [
           { "value": "vue", "link": "https://github.com/vuejs/vue" },
-          { "value": "element", "link": "https://github.com/ElemeFE/element" },
+          { "value": "element", "link": "https://github.com/femessage/element" },
           { "value": "cooking", "link": "https://github.com/ElemeFE/cooking" },
           { "value": "mint-ui", "link": "https://github.com/ElemeFE/mint-ui" },
           { "value": "vuex", "link": "https://github.com/vuejs/vuex" },
@@ -486,7 +486,7 @@ Vous pouvez aller chercher des infos de suggestions sur un serveur distant.
       loadAll() {
         return [
           { "value": "vue", "link": "https://github.com/vuejs/vue" },
-          { "value": "element", "link": "https://github.com/ElemeFE/element" },
+          { "value": "element", "link": "https://github.com/femessage/element" },
           { "value": "cooking", "link": "https://github.com/ElemeFE/cooking" },
           { "value": "mint-ui", "link": "https://github.com/ElemeFE/mint-ui" },
           { "value": "vuex", "link": "https://github.com/vuejs/vuex" },

--- a/examples/docs/fr-FR/installation.md
+++ b/examples/docs/fr-FR/installation.md
@@ -10,13 +10,13 @@ npm i element-ui -S
 
 ### CDN
 
-Obtenez la dernière version via [unpkg.com/element-ui](https://unpkg.com/element-ui/), et importez le JavaScript et le CSS dans votre page.
+Obtenez la dernière version via [unpkg.com/element-ui](https://unpkg.com/@femessage/element-ui/), et importez le JavaScript et le CSS dans votre page.
 
 ```html
 <!-- import du CSS -->
-<link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-chalk/index.css">
+<link rel="stylesheet" href="https://unpkg.com/@femessage/element-ui/lib/theme-chalk/index.css">
 <!-- import du JavaScript -->
-<script src="https://unpkg.com/element-ui/lib/index.js"></script>
+<script src="https://unpkg.com/@femessage/element-ui/lib/index.js"></script>
 ```
 
 :::tip

--- a/examples/docs/fr-FR/layout.md
+++ b/examples/docs/fr-FR/layout.md
@@ -315,7 +315,7 @@ Se basant sur le design responsive de Bootstrap, il existe cinq breakpoints déj
 Element fournit également une série de classes pour cacher des éléments dans certaines circonstances. Ces classes peuvent être ajoutées à n'importe quel élément du DOM ou composant. Vous devrez importer le fichier CSS suivant pour pouvoir les utiliser:
 
 ```js
-import 'element-ui/lib/theme-chalk/display.css';
+import '@femessage/element-ui/lib/theme-chalk/display.css';
 ```
 
 Ces classes sont:

--- a/examples/docs/fr-FR/loading.md
+++ b/examples/docs/fr-FR/loading.md
@@ -175,7 +175,7 @@ Affichez une animation en plein écran quand vous charger des données.
 Vous pouvez invoquer Loading comme un service. Importez le service Loading:
 
 ```javascript
-import { Loading } from 'element-ui';
+import { Loading } from '@femessage/element-ui';
 ```
 Et invoquer-le:
 

--- a/examples/docs/fr-FR/message-box.md
+++ b/examples/docs/fr-FR/message-box.md
@@ -166,7 +166,7 @@ Il est possible d'afficher du contenu un peu plus varié et personnalisé.
 :::
 
 :::tip
-Le contenu de MessageBox peut être `VNode`, Vous permettant de passer des composants personnalisés. Lorsque vous ouvrer MessageBox, Vue compare le nouveau `VNode` avec l'ancien `VNode`, puis détermine comment rafraîchir efficacement l'UI, le composant peut donc ne pas être totalement re-rendu ([#8931](https://github.com/ElemeFE/element/issues/8931)). Dans ce cas, Vous pouvez ajouter une clé unique à `VNode` à chaque fois que MessageBox s'ouvre: [exemple](https://jsfiddle.net/zhiyang/ezmhq2ef).
+Le contenu de MessageBox peut être `VNode`, Vous permettant de passer des composants personnalisés. Lorsque vous ouvrer MessageBox, Vue compare le nouveau `VNode` avec l'ancien `VNode`, puis détermine comment rafraîchir efficacement l'UI, le composant peut donc ne pas être totalement re-rendu ([#8931](https://github.com/femessage/element/issues/8931)). Dans ce cas, Vous pouvez ajouter une clé unique à `VNode` à chaque fois que MessageBox s'ouvre: [exemple](https://jsfiddle.net/zhiyang/ezmhq2ef).
 :::
 
 ### Utiliser du HTML
@@ -290,7 +290,7 @@ Si Element est importé entièrement, il ajoutera les méthodes suivantes à Vue
 Si vous préférer importer `MessageBox` à la demande:
 
 ```javascript
-import { MessageBox } from 'element-ui';
+import { MessageBox } from '@femessage/element-ui';
 ```
 
 Les méthodes correspondantes sont: `MessageBox`, `MessageBox.alert`, `MessageBox.confirm` et `MessageBox.prompt`. Les paramètres sont les mêmes que précédemment.

--- a/examples/docs/fr-FR/message.md
+++ b/examples/docs/fr-FR/message.md
@@ -195,7 +195,7 @@ Element ajoute une méthode `$message` à Vue.prototype. Vous pouvez donc appele
 Importez `Message`:
 
 ```javascript
-import { Message } from 'element-ui';
+import { Message } from '@femessage/element-ui';
 ```
 
 Dans ce cas il faudra appeler `Message(options)`. Les méthodes des différents types sont aussi ajoutées, e.g. `Message.success(options)`. Vous pouvez appeler `Message.closeAll()` pour fermer manuellement toutes les instances.

--- a/examples/docs/fr-FR/notification.md
+++ b/examples/docs/fr-FR/notification.md
@@ -285,7 +285,7 @@ Element ajoute la méthode `$notify` à Vue.prototype. Vous pouvez donc appeler 
 Importez `Notification`:
 
 ```javascript
-import { Notification } from 'element-ui';
+import { Notification } from '@femessage/element-ui';
 ```
 
 Dans ce cas vous devrez appeler `Notification(options)`. Il existe aussi des méthodes pour chaque type, e.g. `Notification.success(options)`. Vous pouvez appeler `Notification.closeAll()` pour fermer manuellement toutes les instances.

--- a/examples/docs/fr-FR/quickstart.md
+++ b/examples/docs/fr-FR/quickstart.md
@@ -22,8 +22,8 @@ Dans main.js:
 
 ```javascript
 import Vue from 'vue';
-import ElementUI from 'element-ui';
-import 'element-ui/lib/theme-chalk/index.css';
+import ElementUI from '@femessage/element-ui';
+import '@femessage/element-ui/lib/theme-chalk/index.css';
 import App from './App.vue';
 
 Vue.use(ElementUI);
@@ -67,7 +67,7 @@ Ensuite, si vous n'avez besoin que de Button et Select, éditez main.js comme su
 
 ```javascript
 import Vue from 'vue';
-import { Button, Select } from 'element-ui';
+import { Button, Select } from '@femessage/element-ui';
 import App from './App.vue';
 
 Vue.component(Button.name, Button);
@@ -83,7 +83,7 @@ new Vue({
 });
 ```
 
-Exemple complet (liste complète des composants dans [components.json](https://github.com/ElemeFE/element/blob/master/components.json)):
+Exemple complet (liste complète des composants dans [components.json](https://github.com/femessage/element/blob/master/components.json)):
 
 ```javascript
 import Vue from 'vue';
@@ -165,7 +165,7 @@ import {
   MessageBox,
   Message,
   Notification
-} from 'element-ui';
+} from '@femessage/element-ui';
 
 Vue.use(Pagination);
 Vue.use(Dialog);
@@ -260,7 +260,7 @@ Import total d'Element：
 
 ```js
 import Vue from 'vue';
-import Element from 'element-ui';
+import Element from '@femessage/element-ui';
 Vue.use(Element, { size: 'small', zIndex: 3000 });
 ```
 
@@ -268,7 +268,7 @@ Import partiel d'Element：
 
 ```js
 import Vue from 'vue';
-import { Button } from 'element-ui';
+import { Button } from '@femessage/element-ui';
 
 Vue.prototype.$ELEMENT = { size: 'small', zIndex: 3000 };
 Vue.use(Button);

--- a/examples/docs/fr-FR/transition.md
+++ b/examples/docs/fr-FR/transition.md
@@ -146,9 +146,9 @@ Pour l'effet collapse, utilisez le composant `el-collapse-transition`.
 
 ```js
 // fade/zoom
-import 'element-ui/lib/theme-chalk/base.css';
+import '@femessage/element-ui/lib/theme-chalk/base.css';
 // collapse
-import CollapseTransition from 'element-ui/lib/transitions/collapse-transition';
+import CollapseTransition from '@femessage/element-ui/lib/transitions/collapse-transition';
 import Vue from 'vue'
 
 Vue.component(CollapseTransition.name, CollapseTransition)

--- a/examples/docs/zh-CN/custom-theme.md
+++ b/examples/docs/zh-CN/custom-theme.md
@@ -20,15 +20,15 @@ Element 的 theme-chalk 使用 SCSS 编写，如果你的项目也使用了 SCSS
 $--color-primary: teal;
 
 /* 改变 icon 字体路径变量，必需 */
-$--font-path: '~element-ui/lib/theme-chalk/fonts';
+$--font-path: '~@femessage/element-ui/lib/theme-chalk/fonts';
 
-@import "~element-ui/packages/theme-chalk/src/index";
+@import "~@femessage/element-ui/packages/theme-chalk/src/index";
 ```
 
 之后，在项目的入口文件中，直接引入以上样式文件即可（无需引入 Element 编译好的 CSS 文件）：
 ```JS
 import Vue from 'vue'
-import Element from 'element-ui'
+import Element from '@femessage/element-ui'
 import './element-variables.scss'
 
 Vue.use(Element)
@@ -44,7 +44,7 @@ Vue.use(Element)
 
 ```javascript
 import '../theme/index.css'
-import ElementUI from 'element-ui'
+import ElementUI from '@femessage/element-ui'
 import Vue from 'vue'
 
 Vue.use(ElementUI)

--- a/examples/docs/zh-CN/i18n.md
+++ b/examples/docs/zh-CN/i18n.md
@@ -5,8 +5,8 @@ Element 组件内部默认使用中文，若希望使用其他语言，则需要
 ```javascript
 // 完整引入 Element
 import Vue from 'vue'
-import ElementUI from 'element-ui'
-import locale from 'element-ui/lib/locale/lang/en'
+import ElementUI from '@femessage/element-ui'
+import locale from '@femessage/element-ui/lib/locale/lang/en'
 
 Vue.use(ElementUI, { locale })
 ```
@@ -16,9 +16,9 @@ Vue.use(ElementUI, { locale })
 ```javascript
 // 按需引入 Element
 import Vue from 'vue'
-import { Button, Select } from 'element-ui'
-import lang from 'element-ui/lib/locale/lang/en'
-import locale from 'element-ui/lib/locale'
+import { Button, Select } from '@femessage/element-ui'
+import lang from '@femessage/element-ui/lib/locale/lang/en'
+import locale from '@femessage/element-ui/lib/locale'
 
 // 设置语言
 locale.use(lang)
@@ -34,7 +34,7 @@ Vue.component(Select.name, Select)
 ```javascript
 {
   plugins: [
-    new webpack.NormalModuleReplacementPlugin(/element-ui[\/\\]lib[\/\\]locale[\/\\]lang[\/\\]zh-CN/, 'element-ui/lib/locale/lang/en')
+    new webpack.NormalModuleReplacementPlugin(/@femessage[\/\\]element-ui[\/\\]lib[\/\\]locale[\/\\]lang[\/\\]zh-CN/, '@femessage/element-ui/lib/locale/lang/en')
   ]
 }
 ```
@@ -46,9 +46,9 @@ Element 兼容 [vue-i18n@5.x](https://github.com/kazupon/vue-i18n)，搭配使�
 ```javascript
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
-import Element from 'element-ui'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import Element from '@femessage/element-ui'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(VueI18n)
 Vue.use(Element)
@@ -63,9 +63,9 @@ Vue.locale('en', enLocale)
 
 ```javascript
 import Vue from 'vue'
-import Element from 'element-ui'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import Element from '@femessage/element-ui'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(Element, {
   i18n: function (path, options) {
@@ -80,10 +80,10 @@ Vue.use(Element, {
 
 ```javascript
 import Vue from 'vue'
-import Element from 'element-ui'
+import Element from '@femessage/element-ui'
 import VueI18n from 'vue-i18n'
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
 
 Vue.use(VueI18n)
 
@@ -117,9 +117,9 @@ import Vue from 'vue'
 import DatePicker from 'element/lib/date-picker'
 import VueI18n from 'vue-i18n'
 
-import enLocale from 'element-ui/lib/locale/lang/en'
-import zhLocale from 'element-ui/lib/locale/lang/zh-CN'
-import ElementLocale from 'element-ui/lib/locale'
+import enLocale from '@femessage/element-ui/lib/locale/lang/en'
+import zhLocale from '@femessage/element-ui/lib/locale/lang/zh-CN'
+import ElementLocale from '@femessage/element-ui/lib/locale'
 
 Vue.use(VueI18n)
 Vue.use(DatePicker)
@@ -147,8 +147,8 @@ ElementLocale.i18n((key, value) => i18n.t(key, value))
 
 ```html
 <script src="//unpkg.com/vue"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="//unpkg.com/@femessage/element-ui"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   ELEMENT.locale(ELEMENT.lang.en)
@@ -160,9 +160,9 @@ ElementLocale.i18n((key, value) => i18n.t(key, value))
 ```html
 <script src="//unpkg.com/vue"></script>
 <script src="//unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/zh-CN.js"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="//unpkg.com/@femessage/element-ui"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/zh-CN.js"></script>
+<script src="//unpkg.com/@femessage/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   Vue.locale('en', ELEMENT.lang.en)
@@ -225,4 +225,4 @@ ElementLocale.i18n((key, value) => i18n.t(key, value))
   <li>世界语 (eo)</li>
 </ul>
 
-如果你需要使用其他的语言，欢迎贡献 PR：只需在 [这里](https://github.com/ElemeFE/element/tree/dev/src/locale/lang) 添加一个语言配置文件即可。
+如果你需要使用其他的语言，欢迎贡献 PR：只需在 [这里](https://github.com/femessage/element/tree/dev/src/locale/lang) 添加一个语言配置文件即可。

--- a/examples/docs/zh-CN/layout.md
+++ b/examples/docs/zh-CN/layout.md
@@ -314,7 +314,7 @@
 Element 额外提供了一系列类名，用于在某些条件下隐藏元素。这些类名可以添加在任何 DOM 元素或自定义组件上。如果需要，请自行引入以下文件：
 
 ```js
-import 'element-ui/lib/theme-chalk/display.css';
+import '@femessage/element-ui/lib/theme-chalk/display.css';
 ```
 
 包含的类名及其含义为：

--- a/examples/docs/zh-CN/loading.md
+++ b/examples/docs/zh-CN/loading.md
@@ -172,7 +172,7 @@
 ### 服务
 Loading 还可以以服务的方式调用。引入 Loading 服务：
 ```javascript
-import { Loading } from 'element-ui';
+import { Loading } from '@femessage/element-ui';
 ```
 在需要调用时：
 ```javascript

--- a/examples/docs/zh-CN/message-box.md
+++ b/examples/docs/zh-CN/message-box.md
@@ -163,7 +163,7 @@
 :::
 
 :::tip
-弹出层的内容可以是 `VNode`，所以我们能把一些自定义组件传入其中。每次弹出层打开后，Vue 会对新老 `VNode` 节点进行比对，然后将根据比较结果进行最小单位地修改视图。这也许会造成弹出层内容区域的组件没有重新渲染，例如 [#8931](https://github.com/ElemeFE/element/issues/8931)。当这类问题出现时，解决方案是给 `VNode` 加上一个不相同的 key，参考[这里](https://jsfiddle.net/zhiyang/ezmhq2ef/)。
+弹出层的内容可以是 `VNode`，所以我们能把一些自定义组件传入其中。每次弹出层打开后，Vue 会对新老 `VNode` 节点进行比对，然后将根据比较结果进行最小单位地修改视图。这也许会造成弹出层内容区域的组件没有重新渲染，例如 [#8931](https://github.com/femessage/element/issues/8931)。当这类问题出现时，解决方案是给 `VNode` 加上一个不相同的 key，参考[这里](https://jsfiddle.net/zhiyang/ezmhq2ef/)。
 :::
 
 ### 使用 HTML 片段
@@ -315,7 +315,7 @@
 如果单独引入 `MessageBox`：
 
 ```javascript
-import { MessageBox } from 'element-ui';
+import { MessageBox } from '@femessage/element-ui';
 ```
 
 那么对应于上述四个全局方法的调用方法依次为：MessageBox, MessageBox.alert, MessageBox.confirm 和 MessageBox.prompt，调用参数与全局方法相同。

--- a/examples/docs/zh-CN/message.md
+++ b/examples/docs/zh-CN/message.md
@@ -193,7 +193,7 @@ Element 为 Vue.prototype 添加了全局方法 $message。因此在 vue instanc
 单独引入 `Message`：
 
 ```javascript
-import { Message } from 'element-ui';
+import { Message } from '@femessage/element-ui';
 ```
 
 此时调用方法为 `Message(options)`。我们也为每个 type 定义了各自的方法，如 `Message.success(options)`。并且可以调用 `Message.closeAll()` 手动关闭所有实例。

--- a/examples/docs/zh-CN/notification.md
+++ b/examples/docs/zh-CN/notification.md
@@ -283,7 +283,7 @@ Element 为 `Vue.prototype` 添加了全局方法 `$notify`。因此在 vue inst
 单独引入 Notification：
 
 ```javascript
-import { Notification } from 'element-ui';
+import { Notification } from '@femessage/element-ui';
 ```
 
 此时调用方法为 `Notification(options)`。我们也为每个 type 定义了各自的方法，如 `Notification.success(options)`。并且可以调用 `Notification.closeAll()` 手动关闭所有实例。

--- a/examples/docs/zh-CN/quickstart.md
+++ b/examples/docs/zh-CN/quickstart.md
@@ -83,7 +83,7 @@ new Vue({
 });
 ```
 
-完整组件列表和引入方式（完整组件列表以 [components.json](https://github.com/ElemeFE/element/blob/master/components.json) 为准）
+完整组件列表和引入方式（完整组件列表以 [components.json](https://github.com/femessage/element/blob/master/components.json) 为准）
 
 ```javascript
 import Vue from 'vue';

--- a/examples/docs/zh-CN/transition.md
+++ b/examples/docs/zh-CN/transition.md
@@ -146,9 +146,9 @@ Element 内应用在部分组件的过渡动画，你也可以直接使用。在
 
 ```js
 // fade/zoom 等
-import 'element-ui/lib/theme-chalk/base.css';
+import '@femessage/element-ui/lib/theme-chalk/base.css';
 // collapse 展开折叠
-import CollapseTransition from 'element-ui/lib/transitions/collapse-transition';
+import CollapseTransition from '@femessage/element-ui/lib/transitions/collapse-transition';
 import Vue from 'vue'
 
 Vue.component(CollapseTransition.name, CollapseTransition)

--- a/examples/pages/template/changelog.tpl
+++ b/examples/pages/template/changelog.tpl
@@ -138,7 +138,7 @@
   <div class="page-changelog">
     <div class="heading">
       <el-button class="fr">
-        <a href="https://github.com/ElemeFE/element/releases" target="_blank">GitHub Releases</a>
+        <a href="https://github.com/femessage/element/releases" target="_blank">GitHub Releases</a>
       </el-button>
       <%= 1 >
     </div>
@@ -165,7 +165,7 @@
       let a = changeLogNodes[1].querySelector('a');
       a && a.remove();
       let release = changeLogNodes[1].textContent.trim();
-      let fragments = `<li><h3><a href="https://github.com/ElemeFE/element/releases/tag/v${release}" target="_blank">${release}</a></h3>`;
+      let fragments = `<li><h3><a href="https://github.com/femessage/element/releases/tag/v${release}" target="_blank">${release}</a></h3>`;
 
       for (let len = changeLogNodes.length, i = 2; i < len; i++) {
         let node = changeLogNodes[i];
@@ -175,7 +175,7 @@
           fragments += changeLogNodes[i].outerHTML;
         } else {
           release = changeLogNodes[i].textContent.trim();
-          fragments += `</li><li><h3><a href="https://github.com/ElemeFE/element/releases/tag/v${release}" target="_blank">${release}</a></h3>`;
+          fragments += `</li><li><h3><a href="https://github.com/femessage/element/releases/tag/v${release}" target="_blank">${release}</a></h3>`;
         }
       }
       fragments = fragments.replace(/#(\d+)/g, '<a href="https://github.com/ElemeFE/element/issues/$1" target="_blank">#$1</a>');


### PR DESCRIPTION
## why
文档中有些链接或者包名依然指向官方的，需要替换为 FEMessage

## how
先找到哪些需要替换的，逐一替换

## Test
- [x] 更新日志 - releases 链接
  - [ ] release 日志没有同步（需要发版的时候生成
- [x] 安装 - Hello world 文件链接
- [x] 国际化 - 替换包名
- [x] 自定义主题 - 替换包名
- [x] 内置过渡动画 - 按需引入 - 替换包名
- [x] 替换前端统一入口链接
  - [x] v-img
  - [x] el-data-table
  - [x] el-form-renderer
  - [x] update-to-ali
  - [x] el-select-area
  - [x] data-list
  - [x] v-editor
  - [x] el-semver-input
  - [x] el-number-range
  - [x] el-data-tree
  - [x] excel-it
  - [x] log-viewer
  - [x] img-preview
- [x] footer 链接
  - [x] 代码仓库
  - [x] 更新日志
  - [x] 常见问题
  - [x] 反馈建议
  - [x] 贡献指南
  - [ ] 微信公众号图片链接（没有
  - [x] GitHub 组织链接