### PR TITLE
chore: update frontend-infra link

### DIFF
--- a/examples/components/side-nav.vue
+++ b/examples/components/side-nav.vue
@@ -288,7 +288,7 @@
           if (xhr.readyState === 4 && xhr.status === 200) {
             const {data: navs} = JSON.parse(xhr.responseText);
             this.femessageNavs = navs.map(nav => {
-              nav.url = `https://frontend-infra.deepexi.com/home/index.html#/material/${nav.repoName}`;
+              nav.url = `https://frontend-infra.deepexi.com/#/material/${nav.repoName}`;
               return nav;
             }).filter(nav => nav.lib && nav.lib.indexOf('element') > -1);
           }

--- a/examples/components/side-nav.vue
+++ b/examples/components/side-nav.vue
@@ -202,6 +202,7 @@
 <script>
   import bus from '../bus';
   import compoLang from '../i18n/component.json';
+  import {getFemessageNavs} from 'element-ui/src/utils/get-femessage-navs';
 
   export default {
     props: {
@@ -280,24 +281,6 @@
         if (!target.nextElementSibling || target.nextElementSibling.tagName !== 'UL') return;
         this.hideAllMenu();
         event.currentTarget.nextElementSibling.style.height = 'auto';
-      },
-
-      getFemessageNavs() {
-        const xhr = new XMLHttpRequest();
-        xhr.onreadystatechange = _ => {
-          if (xhr.readyState === 4 && xhr.status === 200) {
-            const {data: navs} = JSON.parse(xhr.responseText);
-            this.femessageNavs = navs.map(nav => {
-              nav.url = `https://frontend-infra.deepexi.com/#/material/${nav.repoName}`;
-              return nav;
-            }).filter(nav => nav.lib && nav.lib.indexOf('element') > -1);
-          }
-        };
-        xhr.open(
-          'GET',
-          '//mockapi.eolinker.com/jttjNwp60fc1c9e944fdf1cc494b28a7ca4cfe66bbafee1/open'
-        );
-        xhr.send();
       }
     },
 
@@ -315,7 +298,9 @@
     },
     mounted() {
       this.handleResize();
-      this.getFemessageNavs();
+      getFemessageNavs().then(navs=>{
+        this.femessageNavs = navs;
+      });
       window.addEventListener('resize', this.handleResize);
     },
     beforeDestroy() {

--- a/src/utils/get-femessage-navs.js
+++ b/src/utils/get-femessage-navs.js
@@ -1,6 +1,6 @@
 const defaultBaseUrl = 'https://frontend-infra.deepexi.com/#/material';
 const navListUrl =
-  '//mockapi.eolinker.com/jttjNwp60fc1c9e944fdf1cc494b28a7ca4cfe66bbafee1/open';
+  '//mockapi.eolinker.com/jttjNwp60fc1c9e944fdf1cc494b28a7ca4cfe66bbafee1/prod/open';
 
 // 只要有一个设置了 frontendInfraBaseUrl，就相当于全部都设置了这个值
 export function getFrontendInfraBaseUrl(navs) {

--- a/src/utils/get-femessage-navs.js
+++ b/src/utils/get-femessage-navs.js
@@ -2,6 +2,7 @@ const defaultBaseUrl = 'https://frontend-infra.deepexi.com/#/material';
 const navListUrl =
   '//mockapi.eolinker.com/jttjNwp60fc1c9e944fdf1cc494b28a7ca4cfe66bbafee1/open';
 
+// 只要有一个设置了 frontendInfraBaseUrl，就相当于全部都设置了这个值
 export function getFrontendInfraBaseUrl(navs) {
   const nav = navs.find((nav) => nav.frontendInfraBaseUrl);
 

--- a/src/utils/get-femessage-navs.js
+++ b/src/utils/get-femessage-navs.js
@@ -1,0 +1,37 @@
+const defaultBaseUrl = 'https://frontend-infra.deepexi.com/#/material';
+const navListUrl =
+  '//mockapi.eolinker.com/jttjNwp60fc1c9e944fdf1cc494b28a7ca4cfe66bbafee1/open';
+
+export function getFrontendInfraBaseUrl(navs) {
+  const nav = navs.find((nav) => nav.frontendInfraBaseUrl);
+
+  return nav ? nav.frontendInfraBaseUrl : defaultBaseUrl;
+}
+
+export function getFemessageNavs() {
+  const xhr = new XMLHttpRequest();
+
+  // eslint-disable-next-line no-undef
+  return new Promise((resolve) => {
+    xhr.onreadystatechange = (_) => {
+      if (xhr.readyState === 4 && xhr.status === 200) {
+        const { data: navs } = JSON.parse(xhr.responseText);
+
+        const baseUrl = getFrontendInfraBaseUrl(navs);
+
+        const femessageNavs = navs
+          .map((nav) => {
+            nav.url = `${baseUrl}/${nav.repoName}`;
+            return nav;
+          })
+          .filter((nav) => nav.lib && nav.lib.indexOf('element') > -1);
+
+        resolve(femessageNavs);
+      }
+    };
+
+    xhr.open('GET', navListUrl);
+
+    xhr.send();
+  });
+}

--- a/test/unit/specs/util-get-femessage-navs.js
+++ b/test/unit/specs/util-get-femessage-navs.js
@@ -1,0 +1,46 @@
+import { getFrontendInfraBaseUrl } from 'element-ui/src/utils/get-femessage-navs';
+
+const defaultBaseUrl = 'https://frontend-infra.deepexi.com/#/material';
+
+describe('Utils:getFemessageNavs', () => {
+  it('getFrontendInfraBaseUrl navs is empty', () => {
+    const navs = [];
+
+    const url = getFrontendInfraBaseUrl(navs);
+
+    expect(url).to.equal(defaultBaseUrl);
+  });
+
+  it('getFrontendInfraBaseUrl navs no frontendInfraBaseUrl', () => {
+    const navs = [
+      {
+        repoName: 'update-popup',
+        packageName: '@femessage/update-popup'
+      }
+    ];
+
+    const url = getFrontendInfraBaseUrl(navs);
+
+    expect(url).to.equal(defaultBaseUrl);
+  });
+
+  it('getFrontendInfraBaseUrl navs has frontendInfraBaseUrl', () => {
+    const baseUrl =
+      'https://frontend-infra.deepexi.com/home/index.html#/material';
+    const navs = [
+      {
+        repoName: 'update-popup',
+        packageName: '@femessage/update-popup'
+      },
+      {
+        repoName: 'el-data-table',
+        packageName: '@femessage/el-data-table',
+        frontendInfraBaseUrl: baseUrl
+      }
+    ];
+
+    const url = getFrontendInfraBaseUrl(navs);
+
+    expect(url).to.equal(baseUrl);
+  });
+});


### PR DESCRIPTION
## Why
因 frontend-infra 链接更新，以前的链接已失效

## How
更新 frontend-infra 的跳转链接，链接通过 api 数据返回，没有时则使用回退链接，同时增加单元测试

## Test
![image](https://user-images.githubusercontent.com/27952659/98207623-eac03880-1f76-11eb-8a49-9f658d9f098a.png)
